### PR TITLE
Use correct extension name for error message translation

### DIFF
--- a/Classes/Validation/RecaptchaValidator.php
+++ b/Classes/Validation/RecaptchaValidator.php
@@ -54,7 +54,7 @@ class RecaptchaValidator extends AbstractValidator
             $status = $captcha->validateReCaptcha();
 
             if (!$status || $status['error'] !== '') {
-                $errorText = $this->translateErrorMessage('error_recaptcha_' . $status['error'], 'recaptcha');
+                $errorText = $this->translateErrorMessage('error_recaptcha_' . $status['error'], 'ns_friendlycaptcha');
 
                 if (empty($errorText)) {
                     $errorText = htmlspecialchars($status['error']);


### PR DESCRIPTION
TYPO3 will throw an InvalidArgumentException

`Package with key "recaptcha" not found`

if the extension `recaptcha` isn't installed and the validation fails (because no secret is configured)